### PR TITLE
fix setup-r release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
   using: composite
   steps:
       - name: Install R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
         with:
           install-r: false
 


### PR DESCRIPTION
our nightly build is failing because the master branch at the R actions seems to be vanished