### PR TITLE
Use local docker action in composite action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
   using: composite
   steps:
     - name: Validate cff
-      uses: dieghernan/cff-validator/docker@main
+      uses: ./docker
       with:
         cffpath: "${{ inputs.citation-path }}"
 


### PR DESCRIPTION
Fixes #26 

The original code pinned to `docker@main`. That means that, even in a separate branch or even a pinned commit SHA version of the composite action, still the underlying docker action was used from `main`, which is not pinned and may change at any point in time.

Changing to the local version of the docker action enables pinning to full-length commit SHA's for users of this action

